### PR TITLE
Added a feature to the replacer to allow for disabling HTML character escapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+*.swp

--- a/src/templater.js
+++ b/src/templater.js
@@ -50,8 +50,19 @@
       }
     }
 
-    // return a function to use the replacement values
-    return function(data, should_escape = true) {
+    /**
+		 * @param {Object} data An object whose keys match the replacement strings
+		 *   in your template
+		 * @param {Object} opts An optional object containing options to use during
+		 *   template string replacement
+		 * @return Function to use the replacement values
+		 */
+    return function(data, opts) {
+			if (opts === undefined) {
+				opts = {
+					autoescape: true
+				}
+			}
 
       // regex for the #if, body, /if
       var start = "{{\\s?#if\\s+(!)?\\((.+)\\)\\s?}}",
@@ -131,7 +142,7 @@
             "'": "&#39;"
           };
 
-          return should_escape ? replacements[tag] || tag : tag;
+          return !!opts.autoescape ? replacements[tag] || tag : tag;
         }));
       });
 

--- a/src/templater.js
+++ b/src/templater.js
@@ -51,7 +51,7 @@
     }
 
     // return a function to use the replacement values
-    return function(data) {
+    return function(data, should_escape = true) {
 
       // regex for the #if, body, /if
       var start = "{{\\s?#if\\s+(!)?\\((.+)\\)\\s?}}",
@@ -60,12 +60,8 @@
           // save a reference to the template so it can be restored at the end
           tmpl = template,
           props = [],
-          should_escape = true,
           match;
 
-			if (data.should_escape !== undefined) {
-				should_escape = data.should_escape
-			}
       // get all properties with values
       traverse(data, props);
 

--- a/src/templater.js
+++ b/src/templater.js
@@ -60,8 +60,12 @@
           // save a reference to the template so it can be restored at the end
           tmpl = template,
           props = [],
+          should_escape = true,
           match;
 
+			if (data.should_escape !== undefined) {
+				should_escape = data.should_escape
+			}
       // get all properties with values
       traverse(data, props);
 
@@ -119,7 +123,9 @@
 
         // replace the instances in the template with the property value
         // (escaping characters if necessary)
-        template = template.replace(new RegExp(regex, "g"), value.replace(/[&<>"']/g, function(tag) {
+        template = template.replace(
+					new RegExp(regex, "g"), 
+					value.replace(/[&<>"']/g, function(tag) {
           // characters mapped to their entities
           var replacements = {
             "&": "&amp;",
@@ -129,7 +135,7 @@
             "'": "&#39;"
           };
 
-          return replacements[tag] || tag;
+          return should_escape ? replacements[tag] || tag : tag;
         }));
       });
 

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -64,10 +64,9 @@ describe("Basic Tests", function() {
     var template = templater("{{foo}}"),
         context = {
           foo: "<html> tag with 'single' & \"double\" quotes",
-					should_escape: false
         };
 
-    assert.equal(template(context), "<html> tag with 'single' & \"double\" quotes");
+    assert.equal(template(context, false), "<html> tag with 'single' & \"double\" quotes");
   });
 
 });

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -66,7 +66,7 @@ describe("Basic Tests", function() {
           foo: "<html> tag with 'single' & \"double\" quotes",
         };
 
-    assert.equal(template(context, false), "<html> tag with 'single' & \"double\" quotes");
+    assert.equal(template(context, { autoescape: false }), "<html> tag with 'single' & \"double\" quotes");
   });
 
 });

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -59,4 +59,15 @@ describe("Basic Tests", function() {
 
     assert.equal(template(context), "&lt;html&gt; tag with &#39;single&#39; &amp; &quot;double&quot; quotes");
   });
+	
+  it("should not escape certain characters escape has been disabled", function() {
+    var template = templater("{{foo}}"),
+        context = {
+          foo: "<html> tag with 'single' & \"double\" quotes",
+					should_escape: false
+        };
+
+    assert.equal(template(context), "<html> tag with 'single' & \"double\" quotes");
+  });
+
 });


### PR DESCRIPTION
# About
I've been using this library to build up some simple HTML in combination with HTMX.  Being able to nest HTML elements has proved very helpful, but currently this templater doesn't provide a way to not escape characters.  I've added a new `should_escape` value to the `data` object that is handed in in order to disable escape characters on demand.